### PR TITLE
fix(exportfunctions): deep directory case was broken

### DIFF
--- a/src/export-functions.ts
+++ b/src/export-functions.ts
@@ -16,7 +16,7 @@ export function funcNameFromRelPathDefault(relPath: string): string {
   const funcName = relDirPathFunctionNameChunk
     ? `${relDirPathFunctionNameChunk}${sep}${fileNameFunctionNameChunk}`
     : fileNameFunctionNameChunk;
-  return funcName.replace(sep, '-');
+  return funcName.split(sep).join('-');
 }
 
 /**


### PR DESCRIPTION
When one has a folder structure such as:
- src
  - user
    - onCreate.func.ts
  - db
    - posts
      - onCreate.func.ts
      - onDelete.func.ts

When using the glob: `**/*[tj].s`

The method that gets the function names would return
```
user-onCreate
db-posts
db-posts
```

This happened because the call to `replace` only replaces the first
slash. Ideally we would use `replaceAll` but that isn't part of the JS
spec yet.